### PR TITLE
Added syntax for powershell comments.

### DIFF
--- a/src/comment-styles.js
+++ b/src/comment-styles.js
@@ -34,6 +34,11 @@ const commentStyles = {
   },
   'scm, rkt, clj, lisp, cl': {
     inline: ';'
+  },
+  'powershell': {
+    start: '<#',
+    end: '#>',
+    inline: '#'
   }
 };
 


### PR DESCRIPTION
So not much is changed here obviously, just added the syntax for powershell comments.  I noticed that most of the blocks seemed to have file extensions as the key. I figured because powershell uses a couple different extensions I should just use the language name.  If that's problematic let me know and I can just list all the file extensions instead.  

Anyway, cool tool, thanks for writing it!